### PR TITLE
feat: add bmad.config.yaml for team customization (config layer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bmad.config.yaml

--- a/README.md
+++ b/README.md
@@ -93,6 +93,24 @@ sessions_spawn({
 });
 ```
 
+## Team Customization
+
+Teams can customize agent names, inject company context, and remap OpenClaw agent IDs
+**without forking** the repo. Create a `bmad.config.yaml` in your project root:
+
+```yaml
+company:
+  name: "Your Company"
+  tech_stack: "Your stack"
+agents:
+  product-manager:
+    name: "Priya"
+    openclaw_agent_id: "priya"
+```
+
+No config file = current behavior unchanged. See [docs/configuration.md](docs/configuration.md)
+for the full reference and all supported fields.
+
 ## Credits
 
 Based on the [BMad Method v6](https://github.com/bmadcode/BMAD-METHOD) by BMad Code.

--- a/agents/product-manager.md
+++ b/agents/product-manager.md
@@ -1,4 +1,4 @@
-# Product Manager Agent — John 📋
+# Product Manager Agent — {{agent_name|John}} {{agent_emoji|📋}}
 
 ## Persona
 

--- a/bmad.config.example.yaml
+++ b/bmad.config.example.yaml
@@ -1,0 +1,89 @@
+# bmad.config.example.yaml — Team customization for BMAD_Openclaw
+# ─────────────────────────────────────────────────────────────────
+# Copy this file to bmad.config.yaml in your project root,
+# then uncomment and edit the fields you want to customize.
+#
+# No config file = current behavior (zero breaking changes).
+# Partial config is fine — override only what you need.
+#
+# IDE autocomplete (VS Code YAML extension):
+# yaml-language-server: $schema=./bmad.config.schema.json
+
+# Schema version — must be "1" for v1
+# version: "1"
+
+# ─────────────────────────────────────────────────────────────────
+# Company context — injected into all agent prompts as background
+# knowledge. Agents will be aware of this context when they work.
+# ─────────────────────────────────────────────────────────────────
+# company:
+#   name: "Acme Corp"                        # Resolves {{company_name}}
+#   context: |                               # Resolves {{company_context}}
+#     B2B SaaS for the logistics industry.
+#     Prioritize reliability and compliance over speed.
+#     All decisions require audit trails.
+#   tech_stack: "TypeScript, Next.js, PostgreSQL, Kubernetes"  # {{tech_stack}}
+#   conventions: |                           # Resolves {{conventions}}
+#     Post decisions to Notion, not Slack.
+#     All PRs require two reviewers.
+#     Use conventional commits.
+
+# ─────────────────────────────────────────────────────────────────
+# Agent persona overrides
+# Keys MUST match the canonical role slugs listed below.
+# Unknown keys will produce a warning.
+#
+# Canonical role slugs:
+#   analyst | architect | developer | product-manager | qa-engineer
+#   scrum-master | tech-writer | ux-designer | bmad-master
+# ─────────────────────────────────────────────────────────────────
+# agents:
+#   analyst:
+#     name: "Sofia"                # Overrides default name "Mary"
+#     emoji: "🔍"                  # Overrides default emoji
+#     openclaw_agent_id: "sofia"   # Used for sessions_spawn agentId
+#     persona_append: |            # APPENDED to base persona — never replaces
+#       Uses Perplexity MCP for real-time research. Always cites sources.
+#
+#   architect:
+#     name: "Winston"
+#     emoji: "🏗️"
+#     openclaw_agent_id: "winston"
+#     persona_append: "Prefers boring technology. Documents all decisions as ADRs."
+#
+#   developer:
+#     name: "Diego"
+#     emoji: "🔧"
+#     openclaw_agent_id: "diego"
+#     persona_append: "All code work happens in Coder workspace (agent-workspace-1)."
+#
+#   product-manager:
+#     name: "Priya"
+#     emoji: "📊"
+#     openclaw_agent_id: "priya"
+#     persona_append: ""
+#
+#   qa-engineer:
+#     name: "Quinn"
+#     emoji: "🧪"
+#     openclaw_agent_id: "quinn"
+#
+#   scrum-master:
+#     name: "Lucia"
+#     emoji: "🌙"
+#     openclaw_agent_id: "lucia"
+#
+#   tech-writer:
+#     name: "Maya"
+#     emoji: "📚"
+#     openclaw_agent_id: "maya"
+#
+#   ux-designer:
+#     name: "Sally"
+#     emoji: "🎨"
+#     openclaw_agent_id: "sally"
+#
+#   bmad-master:
+#     name: "BMad Master"
+#     emoji: "🧙"
+#     openclaw_agent_id: "bmad-master"

--- a/bmad.config.schema.json
+++ b/bmad.config.schema.json
@@ -1,0 +1,66 @@
+{
+  "": "http://json-schema.org/draft-07/schema#",
+  "title": "BMAD_Openclaw Configuration",
+  "description": "Team customization config for BMAD_Openclaw. Place bmad.config.yaml in your project root \u2014 the orchestrator reads it at session start. No file = current behavior unchanged.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "enum": [
+        "1"
+      ],
+      "description": "Config schema version. Must be 1 for v1."
+    },
+    "company": {
+      "type": "object",
+      "description": "Company context injected into all agent prompts as background knowledge.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Company name. Resolves {{company_name}} in agent prompts."
+        },
+        "context": {
+          "type": "string",
+          "description": "Company background context (multi-line ok). Resolves {{company_context}}."
+        },
+        "tech_stack": {
+          "type": "string",
+          "description": "Primary tech stack. Resolves {{tech_stack}}."
+        },
+        "conventions": {
+          "type": "string",
+          "description": "Team conventions and norms (multi-line ok). Resolves {{conventions}}."
+        }
+      }
+    },
+    "agents": {
+      "type": "object",
+      "description": "Agent persona overrides. Keys must match canonical role slugs.",
+      "additionalProperties": {
+        "type": "object",
+        "description": "Override for a specific agent role.",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name override. Replaces the agent default name."
+          },
+          "emoji": {
+            "type": "string",
+            "description": "Emoji override. Replaces the agent default emoji."
+          },
+          "openclaw_agent_id": {
+            "type": "string",
+            "description": "OpenClaw agent ID used for sessions_spawn. Falls back to role slug if not set."
+          },
+          "persona_append": {
+            "type": "string",
+            "description": "Text APPENDED to the agent Persona section. Never replaces base persona."
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,189 @@
+# Team Configuration — bmad.config.yaml
+
+BMAD_Openclaw supports a lightweight config file that lets teams customize agent
+personas, inject company context, and remap OpenClaw agent IDs — **without forking
+or modifying any framework files**.
+
+No config file = current behavior unchanged. Every field is optional.
+
+---
+
+## Quick Start
+
+```bash
+# 1. Copy the example config to your project root
+cp bmad.config.example.yaml bmad.config.yaml
+
+# 2. Open bmad.config.yaml and uncomment the fields you want
+# 3. Restart your OpenClaw session — config loads automatically
+```
+
+That's it. The orchestrator reads `bmad.config.yaml` at session start and applies
+your customizations before activating any agent.
+
+---
+
+## Config File Reference
+
+The config file lives at `bmad.config.yaml` in your **project root** (same directory
+where you run OpenClaw). It is YAML and never committed to the BMAD_Openclaw repo —
+only `bmad.config.example.yaml` is shipped.
+
+### `version`
+
+```yaml
+version: "1"
+```
+
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `version` | string | No | — |
+
+Schema version. Must be `"1"` for v1. Omitting it is fine. An unrecognized value
+produces a warning but does not abort.
+
+---
+
+### `company`
+
+Company context injected into all agent prompts as background knowledge.
+
+```yaml
+company:
+  name: "Acme Corp"
+  context: |
+    B2B SaaS for logistics. Prioritize reliability and compliance.
+  tech_stack: "TypeScript, Next.js, PostgreSQL"
+  conventions: |
+    All PRs require two reviewers.
+    Post decisions to Notion, not Slack.
+```
+
+| Field | Type | Required | Resolves | Description |
+|-------|------|----------|----------|-------------|
+| `company.name` | string | No | `{{company_name}}` | Company display name |
+| `company.context` | string | No | `{{company_context}}` | Business context (multi-line ok) |
+| `company.tech_stack` | string | No | `{{tech_stack}}` | Primary tech stack |
+| `company.conventions` | string | No | `{{conventions}}` | Team norms (multi-line ok) |
+
+All `company.*` fields are available as background knowledge to **all** agents.
+
+---
+
+### `agents`
+
+Override individual agent personas. Keys must match canonical role slugs (see table below).
+
+```yaml
+agents:
+  product-manager:
+    name: "Priya"
+    emoji: "\📊"
+    openclaw_agent_id: "priya"
+    persona_append: "Owns sprint planning and Discourse posts."
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agents.ROLE.name` | string | No | Replaces the agent's default display name |
+| `agents.ROLE.emoji` | string | No | Replaces the agent's default emoji |
+| `agents.ROLE.openclaw_agent_id` | string | No | `agentId` used for `sessions_spawn` |
+| `agents.ROLE.persona_append` | string | No | Text **appended** to the Persona section — never replaces base persona |
+
+`persona_append` is additive. The base persona (expertise, principles, communication style)
+always stays intact. Use it to add team-specific notes: tools used, channels to post to, etc.
+
+---
+
+## Canonical Role Keys
+
+| Config key | Default name | Default emoji | File |
+|------------|-------------|---------------|------|
+| `analyst` | Mary | \📊 | `agents/analyst.md` |
+| `architect` | Winston | \\U0001f3d7\\ufe0f | `agents/architect.md` |
+| `developer` | James | \💻 | `agents/developer.md` |
+| `product-manager` | John | \📋 | `agents/product-manager.md` |
+| `qa-engineer` | Quinn | \🔍 | `agents/qa-engineer.md` |
+| `scrum-master` | Bob | \🏃 | `agents/scrum-master.md` |
+| `tech-writer` | Paige | \\u2712\\ufe0f | `agents/tech-writer.md` |
+| `ux-designer` | Sally | \🎨 | `agents/ux-designer.md` |
+| `bmad-master` | BMad Master | \🧙 | `agents/bmad-master.md` |
+
+An unknown key (e.g., a typo) produces a warning but does not abort the session.
+
+---
+
+## Resolution Rules
+
+### Priority (highest wins)
+
+```
+1. bmad.config.yaml — agents.<role>.*     (role-specific overrides)
+2. bmad.config.yaml — company.*           (shared company context)
+3. Agent .md file hardcoded values        (upstream defaults)
+```
+
+### Template Variables — `{{var|default}}` Syntax
+
+Agent files use `{{var|DEFAULT}}` placeholders in their H1 headers. Resolution:
+
+- If `var` is present in config → use the config value.
+- If `var` is absent from config → use `DEFAULT` (the text after `|`).
+
+This makes agent files fully readable and functional without any config. The inline
+default is the upstream value (e.g., `{{agent_name|John}}`).
+
+### `persona_append` Behavior
+
+When `persona_append` is set for a role:
+
+- The orchestrator **appends** the text as an additional paragraph after the existing
+  Persona/Identity section in the agent file.
+- The base persona (role expertise, principles, communication style) is **never modified**.
+- Think of it as a sticky note added on top of the agent's profile.
+
+---
+
+## Backward Compatibility
+
+- **No config file** → identical behavior to pre-config BMAD_Openclaw (zero breaking changes).
+- **Partial config** → only configured fields override; everything else uses file defaults.
+- **Existing forks** → you can gradually migrate manual edits to `bmad.config.yaml` and restore
+  the original agent files.
+- **Overlay directories** → `bmad.config.yaml` can coexist with overlay patterns. Config takes
+  precedence for the fields it defines.
+
+`bmad.config.yaml` is git-ignored by convention (add it to your project's `.gitignore`).
+`bmad.config.example.yaml` is the template committed to the framework repo.
+
+---
+
+## Known Limitations (V1)
+
+The following are **not** supported in v1 — planned for a future release:
+
+| Limitation | Notes |
+|------------|-------|
+| Environment variable interpolation in config values | Use OpenClaw session context for secrets |
+| Routing overrides (`routing:` key) | Planned for V2 |
+| Deeper persona placeholders (beyond H1 headers) | `persona_append` covers most use cases |
+| Per-agent config files | Single unified file is intentional for small teams |
+| Config hot-reload without session restart | Re-read happens at session start |
+
+---
+
+## Manual Test Checklist
+
+Before submitting a PR that touches config behavior, verify these four scenarios:
+
+1. **No config** — Run any workflow without `bmad.config.yaml`. Confirm output is identical
+   to pre-config behavior (agent uses upstream default name and emoji).
+
+2. **Minimal config** — Add `company.name: "TestCo"` only. Confirm agent acknowledges the
+   company name when relevant; no other behavior changes.
+
+3. **Full config** — Add full agent overrides (name, emoji, persona_append). Confirm the
+   agent introduces itself with the configured name/emoji and includes the appended persona text.
+
+4. **Config removed** — Start session with config, then remove `bmad.config.yaml` and restart.
+   Confirm fallback to upstream defaults with no errors.

--- a/workflow/orchestrator.md
+++ b/workflow/orchestrator.md
@@ -1,5 +1,68 @@
 # BMad Method — Orchestrator Rules
 
+## Config Layer
+
+The config layer allows teams to customize agent personas and inject company context
+without forking or modifying any BMAD_Openclaw framework files.
+
+> **Note:** `bmad.config.yaml` is user-created and never overwritten by a framework update.
+> Agent names in this file reflect upstream defaults. If `bmad.config.yaml` is present,
+> names and emojis may be remapped per your team's configuration.
+
+### Config Discovery
+
+At session start, apply the following rules **once** and hold results as "active config":
+
+1. **CHECK** — Does `bmad.config.yaml` exist in the project root?
+   - **YES** → Read and parse it. Proceed to step 2.
+   - **NO** → All agent file defaults apply unchanged. Skip all remaining config steps.
+
+2. **VALIDATE** — If a `version:` field is present and its value is not `"1"`, emit a
+   warning and continue (do not abort).
+
+3. **WARN** — If any key under `agents:` does not match a canonical role slug
+   (`analyst`, `architect`, `developer`, `product-manager`, `qa-engineer`,
+   `scrum-master`, `tech-writer`, `ux-designer`, `bmad-master`), emit a warning
+   (likely a typo). Do not abort.
+
+### Agent Name Resolution
+
+When activating any agent role:
+
+1. **FIND** — Look up `agents.<role-key>` in the active config.
+   - Role not in config → use all file defaults for that agent. Stop here.
+   - Role in config → proceed.
+
+2. **APPLY** field-level overrides (only for fields explicitly present in config):
+   - `agents.<role>.name` → use as the agent's display name
+   - `agents.<role>.emoji` → use in the agent header
+   - `agents.<role>.persona_append` → append as an additional paragraph in the Persona section
+   - `agents.<role>.openclaw_agent_id` → use for `sessions_spawn` agentId
+
+### Company Context Injection
+
+If `company.*` fields are present in the active config:
+
+- Make `company.name`, `company.context`, `company.tech_stack`, and `company.conventions`
+  available as background knowledge when acting as **any** agent.
+- Do **not** expose raw config YAML verbatim to users unless explicitly asked.
+
+### Template Variable Resolution
+
+Agent files may contain `{{var|default}}` placeholders. Resolution rules:
+
+- `{{company_name}}` → `company.name` (or empty string if not set)
+- `{{company_context}}` → `company.context` (or empty string)
+- `{{tech_stack}}` → `company.tech_stack` (or empty string)
+- `{{conventions}}` → `company.conventions` (or empty string)
+- `{{agent_name|DEFAULT}}` → `agents.<role>.name` from config, or `DEFAULT` if not set
+- `{{agent_emoji|DEFAULT}}` → `agents.<role>.emoji` from config, or `DEFAULT` if not set
+
+The text after `|` is the **inline default** — the value used when the variable is absent
+from config. Agent files remain fully functional and readable without any config present.
+
+---
+
 ## Workflow Execution Engine
 
 The workflow execution engine governs all BMad workflow processing. Every workflow follows these rules.


### PR DESCRIPTION
## Summary

This PR adds a lightweight config layer to BMAD_Openclaw that lets teams customize agent personas and inject company context **without forking the repo**.

See RFC: https://github.com/ErwanLorteau/BMAD_Openclaw/issues/1

## Changes

| File | Type | Description |
|------|------|-------------|
| bmad.config.example.yaml | New | Documented example config — all fields commented |
| bmad.config.schema.json | New | JSON schema for IDE autocompletion (VS Code YAML) |
| workflow/orchestrator.md | Modified | Added Config Layer section with resolution rules |
| agents/product-manager.md | Modified | Added template placeholder as PoC |
| docs/configuration.md | New | Full reference documentation |
| README.md | Modified | Added Team Customization section |
| .gitignore | New | Ignores bmad.config.yaml by convention |

## Backward Compatibility

Zero breaking changes. No config file = current behavior identical to pre-PR.

## How It Works

The config loader is instructions in workflow/orchestrator.md - no Python or external tools. Consistent with the project markdown-first style.

Agent files use placeholder syntax - the default is the upstream value, so files remain fully readable without any config present.

## Test Checklist

1. No config -> identical behavior
2. Minimal config (company.name only) -> agent context updated
3. Full config with persona_append -> agent intro uses configured name/emoji
4. Config removed -> fallback to defaults
