### PR TITLE
feat: V3 multi-agent architecture — sub-agent spawning per workflow

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,12 @@
  * Registers agent tools for BMad workflow orchestration.
  * The BMad Master agent calls these tools to execute workflows step-by-step.
  *
- * Architecture (Option B — single session):
- * - Master agent role-plays as BMad agents (Analyst, PM, Architect, etc.)
- * - Plugin tools handle step file loading, persona injection, state tracking
- * - No sub-agents — master does the actual execution
- * - YOLO mode auto-advances through steps
- * - Normal mode halts at checkpoints for user input
+ * Architecture (V3 — multi-agent):
+ * - BMad Master is a top-level agent that orchestrates workflows
+ * - Each workflow spawns a sub-agent (Analyst, PM, Architect, etc.)
+ * - Plugin tools handle step loading, persona injection, state tracking, artifact saving
+ * - YOLO mode: sub-agent runs autonomously
+ * - Interactive mode: sub-agent pauses per step for user feedback
  */
 
 import { join, dirname } from "node:path";
@@ -22,7 +22,6 @@ import * as bmadLoadStep from "./tools/bmad-load-step.ts";
 import * as bmadSaveArtifact from "./tools/bmad-save-artifact.ts";
 import * as bmadCompleteWorkflow from "./tools/bmad-complete-workflow.ts";
 import * as bmadGetState from "./tools/bmad-get-state.ts";
-
 /** All tool modules */
 const TOOLS = [
   bmadInitProject,


### PR DESCRIPTION
## Summary

Implements the V3 multi-agent architecture as described in #8. Each BMad workflow now spawns a dedicated sub-agent instead of running in a single session.

## Changes

**`src/index.ts`** — Updated architecture comment from V2 (single-session) to V3 (multi-agent). Removed prototype spawn tools. Back to 7 tools.

**`src/tools/bmad-start-workflow.ts`** — Task prompt output reformatted for sub-agent spawning:
- Added explicit `projectPath` in tool call instructions (sub-agents need it)
- Added interactive mode pause instructions (stop after each step, wait for feedback)
- Added "complete this workflow and stop" guard rails
- Updated description to reflect new purpose

## Required Config Changes

bmad-master must be a **top-level agent** (not a sub-agent):

```json
{
  "agents": {
    "list": [
      {
        "id": "bmad-master",
        "name": "BMad Master",
        "workspace": "~/.openclaw/workspace-bmad",
        "tools": { "allow": ["bmad-method"] }
      }
    ]
  },
  "tools": {
    "agentToAgent": { "enabled": true, "allow": ["main", "bmad-master"] }
  }
}
```

## How It Works

1. User tells main agent to start a BMad project
2. Main relays to bmad-master via `sessions_send`
3. bmad-master calls `bmad_start_workflow` → gets task prompt
4. bmad-master calls `sessions_spawn(task=prompt)` → specialist sub-agent runs
5. Sub-agent executes all steps autonomously (yolo) or with pauses (interactive)
6. Sub-agent calls `bmad_complete_workflow` → announce back to master
7. Master proposes next workflow

## Test Result

End-to-end YOLO test: 7 steps, 259 lines product brief, workflow marked complete. Zero context bleeding.

See #8 for the full architecture journey from V2 to V3.

Closes #8