### PR TITLE
fix: prevent premature workflow completion without finishing all steps

### DIFF
--- a/src/tools/bmad-complete-workflow.ts
+++ b/src/tools/bmad-complete-workflow.ts
@@ -41,6 +41,15 @@ export async function execute(
   const active = state.activeWorkflow;
   const workflowDef = getWorkflow(active.id);
 
+  // Guard: ensure all steps have been completed before allowing workflow completion
+  if (active.totalSteps && active.currentStep < active.totalSteps) {
+    return text(
+      `Error: Cannot complete workflow "${active.id}" — currently on step ${active.currentStep} of ${active.totalSteps}. ` +
+        `Complete all steps before calling \`bmad_complete_workflow\`. ` +
+        `Use \`bmad_load_step\` to advance to the next step.`
+    );
+  }
+
   // Move to completed
   state.completedWorkflows.push({
     id: active.id,


### PR DESCRIPTION
Fixes #22

`bmad_complete_workflow` now checks `active.currentStep < active.totalSteps` before allowing completion. Returns a clear error message if called prematurely, guiding the agent to finish remaining steps first.

All 30 existing tests pass.